### PR TITLE
Fix interval calculation

### DIFF
--- a/usr.sbin/mcast-proxy/mcast-proxy.h
+++ b/usr.sbin/mcast-proxy/mcast-proxy.h
@@ -43,8 +43,8 @@
  * Group membership interval is composed by the following formula:
  * (Robustness * Query_Interval) + Query_Response_Interval.
  */
-#define IGMP_GROUP_MEMBERSHIP_INTERVAL(r, q) \
-	(((r) * (q)) + IGMP_RESPONSE_INTERVAL)
+#define IGMP_GROUP_MEMBERSHIP_INTERVAL ((IGMP_ROBUSTNESS_DEFVALUE * \
+	IGMP_QUERY_INTERVAL) + IGMP_RESPONSE_INTERVAL)
 
 /* Signalize invalid virtual/multicast interface index. */
 #define INVALID_VINDEX ((uint16_t)-1)

--- a/usr.sbin/mcast-proxy/mrt.c
+++ b/usr.sbin/mcast-proxy/mrt.c
@@ -184,15 +184,11 @@ mrt_delorigin(struct multicast_route *mr, struct intf_data *id,
 void
 mrt_timeradd(struct event *ev)
 {
-	unsigned long	 total = IGMP_GROUP_MEMBERSHIP_INTERVAL(
-	    IGMP_ROBUSTNESS_DEFVALUE, IGMP_QUERY_INTERVAL);
-	struct timeval	 tv;
+	struct timeval	 tv = { IGMP_GROUP_MEMBERSHIP_INTERVAL, 0 };
 
 	if (evtimer_pending(ev, &tv))
 		evtimer_del(ev);
 
-	tv.tv_sec = total;
-	tv.tv_usec = 0;
 	evtimer_add(ev, &tv);
 }
 

--- a/usr.sbin/mcast-proxy/mrt.c
+++ b/usr.sbin/mcast-proxy/mrt.c
@@ -185,7 +185,7 @@ void
 mrt_timeradd(struct event *ev)
 {
 	unsigned long	 total = IGMP_GROUP_MEMBERSHIP_INTERVAL(
-	    IGMP_ROBUSTNESS_DEFVALUE, IGMP_RESPONSE_INTERVAL);
+	    IGMP_ROBUSTNESS_DEFVALUE, IGMP_QUERY_INTERVAL);
 	struct timeval	 tv;
 
 	if (evtimer_pending(ev, &tv))


### PR DESCRIPTION
`IGMP_GROUP_MEMBERSHIP_INTERVAL` should be calculated using `IGMP_QUERY_INTERVAL` instead of `IGMP_RESPONSE_INTERVAL`.

https://github.com/Esdenera/mcast-proxy/blob/master/usr.sbin/mcast-proxy/mcast-proxy.h#L41-L45

While here simply a bit.