### PR TITLE
Allow upstream to receive query and report IGMP messages

### DIFF
--- a/usr.sbin/mcast-proxy/mcast-proxy.c
+++ b/usr.sbin/mcast-proxy/mcast-proxy.c
@@ -605,13 +605,6 @@ igmp_recv(int fd, __unused short ev, __unused void *arg)
 		return;
 	}
 
-	/* Don't receive commands from upstream interface. */
-	if (id == upstreamif) {
-		log_debug("%s: ignoring host command on upstream interface",
-		   __func__);
-		return;
-	}
-
 	switch (igmp->igmp_type) {
 	case IGMP_HOST_MEMBERSHIP_QUERY:
 		break;
@@ -624,6 +617,12 @@ igmp_recv(int fd, __unused short ev, __unused void *arg)
 		    &igmp->igmp_group);
 		break;
 	case IGMP_HOST_LEAVE_MESSAGE:
+		if (id == upstreamif) {
+			log_debug("%s: ignoring command on upstream interface",
+			    __func__);
+			return;
+		}
+
 		mrt_remove4(id, &sstosin(&src)->sin_addr, &igmp->igmp_group);
 		break;
 	}


### PR DESCRIPTION
RFC4605 section 4.1 states "The proxy device performs the host portion of the IGMP/MLD protocol on the upstream interface", and RFC2236 section 6 states "All other events, such as receiving invalid IGMP messages, or IGMP messages other than Query or Report, are ignored in all states".

This change unbreaks an IPTV setup.