### PR TITLE
Prevent overfilling of routing table

### DIFF
--- a/usr.sbin/mcast-proxy/mrt.c
+++ b/usr.sbin/mcast-proxy/mrt.c
@@ -132,6 +132,13 @@ mrt_addorigin(struct multicast_route *mr, struct intf_data *id,
 			    &mr->mr_group, &mr->mr_molist);
 	}
 
+	/* Do not keep upstream as item on the group list. */
+	if (id == upstreamif) {
+		LIST_REMOVE(mo, mo_entry);
+		free(mo);
+		return NULL;
+	}
+
 	return mo;
 }
 

--- a/usr.sbin/mcast-proxy/mrt.c
+++ b/usr.sbin/mcast-proxy/mrt.c
@@ -49,11 +49,9 @@ RB_HEAD(mrtree, multicast_route) mrtree = RB_INITIALIZER(&mrtree);
 
 struct multicast_origin *mo_lookup(struct molist *, struct intf_data *,
     union uaddr *);
-struct multicast_origin *mrt_addorigin(struct multicast_route *,
-    struct intf_data *,union uaddr *);
+void mrt_addorigin(struct multicast_route *, struct intf_data *, union uaddr *);
 void _mrt_delorigin(struct multicast_route *, struct multicast_origin *);
-void mrt_delorigin(struct multicast_route *, struct intf_data *,
-    union uaddr *);
+void mrt_delorigin(struct multicast_route *, struct intf_data *, union uaddr *);
 
 void mrt_timeradd(struct event *);
 void mrt_timer(int, short, void *);
@@ -87,7 +85,7 @@ mo_lookup(struct molist *molist, struct intf_data *id, union uaddr *addr)
 	return NULL;
 }
 
-struct multicast_origin *
+void
 mrt_addorigin(struct multicast_route *mr, struct intf_data *id,
     union uaddr *addr)
 {
@@ -105,13 +103,13 @@ mrt_addorigin(struct multicast_route *mr, struct intf_data *id,
 				    addr, &mr->mr_group, &mr->mr_molist);
 		}
 		mo->mo_alive = 1;
-		return mo;
+		return;
 	}
 
 	mo = calloc(1, sizeof(*mo));
 	if (mo == NULL) {
 		log_warn("%s: calloc", __func__);
-		return NULL;
+		return;
 	}
 
 	LIST_INSERT_HEAD(&mr->mr_molist, mo, mo_entry);
@@ -136,10 +134,7 @@ mrt_addorigin(struct multicast_route *mr, struct intf_data *id,
 	if (id == upstreamif) {
 		LIST_REMOVE(mo, mo_entry);
 		free(mo);
-		return NULL;
 	}
-
-	return mo;
 }
 
 void


### PR DESCRIPTION
Do not add upstream to a group list because it will never be removed from this list, and remain on the routing table. While here refactor mrt_addorigin().